### PR TITLE
Customizable logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,18 @@ module Clockwork
 end
 ```
 
+### log_handler
+
+You can add log_handler to customize the logging of messages.
+
+```ruby
+module Clockwork
+  log_handler do |msg|
+    puts({clock: true, message: msg})
+  end
+end
+```
+
 Old style
 ---------
 

--- a/README.md
+++ b/README.md
@@ -381,6 +381,18 @@ Current specifications are as follows.
 
 Any suggestion about these specifications is welcome.
 
+### error_log_handler
+
+You can add error_log_handler to customize the logging of errors.
+
+```ruby
+module Clockwork
+  error_log_handler do |error|
+    puts({clock: true, at: "exception", error: error.message})
+  end
+end
+```
+
 Old style
 ---------
 

--- a/README.md
+++ b/README.md
@@ -381,6 +381,17 @@ Current specifications are as follows.
 
 Any suggestion about these specifications is welcome.
 
+If an error is not recoverable you may want to exit and allow your process to be restarted.
+
+```ruby
+error_handler do |error|
+  Airbrake.notify_or_ignore(error)
+  if error.kind_of?(PG::Error)
+    exit 1
+  end
+end
+```
+
 ### error_log_handler
 
 You can add error_log_handler to customize the logging of errors.

--- a/lib/clockwork.rb
+++ b/lib/clockwork.rb
@@ -34,6 +34,10 @@ module Clockwork
       Clockwork.manager.error_handler(&block)
     end
 
+    def error_log_handler(&block)
+      Clockwork.manager.error_log_handler(&block)
+    end
+
     def on(event, options={}, &block)
       Clockwork.manager.on(event, options, &block)
     end

--- a/lib/clockwork.rb
+++ b/lib/clockwork.rb
@@ -38,6 +38,10 @@ module Clockwork
       Clockwork.manager.error_log_handler(&block)
     end
 
+    def log_handler(&block)
+      Clockwork.manager.log_handler(&block)
+    end
+
     def on(event, options={}, &block)
       Clockwork.manager.on(event, options, &block)
     end

--- a/lib/clockwork/manager.rb
+++ b/lib/clockwork/manager.rb
@@ -77,8 +77,17 @@ module Clockwork
       events
     end
 
+    def error_log_handler(&block)
+      @error_log_handler = block if block_given?
+      @error_log_handler
+    end
+
     def log_error(e)
-      config[:logger].error(e)
+      if error_log_handler
+        error_log_handler.call(e)
+      else
+        config[:logger].error(e)
+      end
     end
 
     def handle_error(e)

--- a/lib/clockwork/manager.rb
+++ b/lib/clockwork/manager.rb
@@ -82,6 +82,11 @@ module Clockwork
       @error_log_handler
     end
 
+    def log_handler(&block)
+      @log_handler = block if block_given?
+      @log_handler
+    end
+
     def log_error(e)
       if error_log_handler
         error_log_handler.call(e)
@@ -95,7 +100,11 @@ module Clockwork
     end
 
     def log(msg)
-      config[:logger].info(msg)
+      if log_handler
+        log_handler.call(msg)
+      else
+        config[:logger].info(msg)
+      end
     end
 
     private

--- a/test/clockwork_test.rb
+++ b/test/clockwork_test.rb
@@ -80,4 +80,14 @@ class ClockworkTest < Test::Unit::TestCase
     Clockwork.run
     assert $called
   end
+  
+  test 'should pass error_log_handler to the manager' do
+    Clockwork.manager.expects(:error_log_handler).yields.then.returns
+
+    module ::Clockwork
+      error_log_handler do |error| 
+        # log the error in a non-standard way
+      end
+    end
+  end
 end

--- a/test/clockwork_test.rb
+++ b/test/clockwork_test.rb
@@ -90,4 +90,14 @@ class ClockworkTest < Test::Unit::TestCase
       end
     end
   end
+
+  test 'should pass log_handler to the manager' do
+    Clockwork.manager.expects(:log_handler).yields.then.returns
+
+    module ::Clockwork
+      log_handler do |message|
+        # log the message in a non-standard way
+      end
+    end
+  end
 end

--- a/test/manager_test.rb
+++ b/test/manager_test.rb
@@ -9,9 +9,7 @@ require 'active_support/test_case'
 class ManagerTest < ActiveSupport::TestCase
   setup do
     @manager = Clockwork::Manager.new
-    class << @manager
-      def log(msg); end
-    end
+    @manager.log_handler {}
     @manager.handler { }
   end
 
@@ -370,6 +368,18 @@ class ManagerTest < ActiveSupport::TestCase
     end
 
     @manager.log_error(RuntimeError.new('yo!'))
+    assert_true handler_called
+  end
+
+  test "logging is configurable" do
+    handler_called = false
+
+    @manager.log_handler do |msg|
+      handler_called = true
+      assert_equal "message", msg
+    end
+
+    @manager.log("message")
     assert_true handler_called
   end
 

--- a/test/manager_test.rb
+++ b/test/manager_test.rb
@@ -361,6 +361,18 @@ class ManagerTest < ActiveSupport::TestCase
     end
   end
 
+  test "error logging is configurable" do
+    handler_called = false
+
+    @manager.error_log_handler do |error|
+      handler_called = true
+      assert_equal "yo!", error.message
+    end
+
+    @manager.log_error(RuntimeError.new('yo!'))
+    assert_true handler_called
+  end
+
   describe 'error_handler' do
     setup do
       @errors = []


### PR DESCRIPTION
This allows the logging of messages and errors to be customized for the case where the logger does not conform to `logger.error(e)` and `logger.info(msg)` interface.

Thinking about this more now though perhaps I could have just injected an adapter object that expected calls to `error` and `info` and passed them to my logger in the format it expects.