### PR TITLE
Make compatible with active support 2.x

### DIFF
--- a/lib/clockwork.rb
+++ b/lib/clockwork.rb
@@ -1,5 +1,5 @@
 require 'logger'
-require 'active_support/time'
+require 'active_support/core_ext/time'
 
 require 'clockwork/at'
 require 'clockwork/event'


### PR DESCRIPTION
Active Support 2.x doesn't have `active_support/time` and Clockwork blows up trying to require it. Also, the core class extensions you need are all in `active_support/core_ext/time`.