### PR TITLE
Bufix: file load error prevents clockwork from running

### DIFF
--- a/lib/clockwork/database_events/event_store.rb
+++ b/lib/clockwork/database_events/event_store.rb
@@ -1,3 +1,5 @@
+require_relative './event_collection'
+
 # How EventStore and Clockwork manager events are kept in sync...
 #
 # The normal Clockwork::Manager is responsible for keeping track of


### PR DESCRIPTION
We were getting "`require': cannot load such file -- event_collection (LoadError)" due to the
EventCollection not being required from EventSore.