### PR TITLE
Database-backed events can now set clockwork event :if

### DIFF
--- a/lib/clockwork/database_events/event.rb
+++ b/lib/clockwork/database_events/event.rb
@@ -4,12 +4,13 @@ module Clockwork
 
     class Event < Clockwork::Event
 
-      attr_accessor :event_store, :at
+      attr_accessor :event_store, :model_attributes
 
-      def initialize(manager, period, job, block, event_store, options={})
+      def initialize(manager, period, job, block, event_store, model_attributes, options={})
         super(manager, period, job, block, options)
         @event_store = event_store
         @event_store.register(self, job)
+        @model_attributes = model_attributes
       end
 
       def name

--- a/lib/clockwork/database_events/event_collection.rb
+++ b/lib/clockwork/database_events/event_collection.rb
@@ -14,9 +14,7 @@ module Clockwork
       def has_changed?(model)
         return true if event.nil?
 
-        (has_name? && name != model.name) ||
-          frequency != model.frequency ||
-            ats != model_ats(model)
+        event.model_attributes != model.attributes
       end
 
       def unregister
@@ -27,32 +25,11 @@ module Clockwork
 
       attr_reader :events, :manager
 
+      # All events in the same collection (for a model instance) are equivalent
+      # so we can use any of them. Only their @at variable will be different,
+      # but we don't care about that here.
       def event
         events.first
-      end
-
-      def has_name?
-        event.job_has_name?
-      end
-
-      def name
-        event.name
-      end
-
-      def frequency
-        event.frequency
-      end
-
-      def ats
-        events.collect(&:at).compact
-      end
-
-      def model_ats(model)
-        at_strings_for(model).collect{|at| At.parse(at) }
-      end
-
-      def at_strings_for(model)
-        model.at.to_s.split(',').map(&:strip)
       end
     end
   end

--- a/lib/clockwork/database_events/event_store.rb
+++ b/lib/clockwork/database_events/event_store.rb
@@ -112,10 +112,15 @@ module Clockwork
         options = {
           :from_database => true,
           :synchronizer => self,
-          :at => at_strings_for(model)
         }
 
+        options[:at] = at_strings_for(model) if model.respond_to?(:at)
+        options[:if] = ->(time){ model.if?(time) } if model.respond_to?(:if?)
         options[:tz] = model.tz if model.respond_to?(:tz)
+
+        # store the state of the model at time of registering so we can
+        # easily compare and determine if state has changed later
+        options[:model_attributes] = model.attributes
 
         options
       end

--- a/lib/clockwork/database_events/manager.rb
+++ b/lib/clockwork/database_events/manager.rb
@@ -10,7 +10,11 @@ module Clockwork
 
       def register(period, job, block, options)
         @events << if options[:from_database]
-          Clockwork::DatabaseEvents::Event.new(self, period, job, (block || handler), options.fetch(:synchronizer), options)
+          synchronizer = options.fetch(:synchronizer)
+          model_attributes = options.fetch(:model_attributes)
+
+          Clockwork::DatabaseEvents::Event.
+            new(self, period, job, (block || handler), synchronizer, model_attributes, options)
         else
           Clockwork::Event.new(self, period, job, block || handler, options)
         end

--- a/test/database_events/support/active_record_fake.rb
+++ b/test/database_events/support/active_record_fake.rb
@@ -23,6 +23,10 @@ module ActiveRecordFake
     set_attribute_values_from_options options
   end
 
+  def attributes
+    Hash[instance_variables.map { |name| [name, instance_variable_get(name)] } ]
+  end
+
   module ClassMethods
     def create *args
       new *args

--- a/test/database_events/test_helpers.rb
+++ b/test/database_events/test_helpers.rb
@@ -56,3 +56,16 @@ class DatabaseEventModelWithoutName
   include ActiveRecordFake
   attr_accessor :frequency, :at
 end
+
+class DatabaseEventModelWithIf
+  include ActiveRecordFake
+  attr_accessor :name, :frequency, :at, :tz, :if_state
+
+  def name
+    @name || "#{self.class}:#{id}"
+  end
+
+  def if?(time)
+    @if_state
+  end
+end


### PR DESCRIPTION
## Background

An oft-requested feature is to make Database-backed events somehow work with clockwork's `:if` option. For a long time, this seemed impossible to me because the only approach I could envisage was to store Ruby code in a text field in the database model, and `eval` it - clearly a bad idea! However, @adrianpcastro in #153 suggested an infinitely better approach, that for some reason eluded me: simply having a `if`-like method in the database model.

This commit implements that approach, and finally allows Database-backed events to use `:if`s in the same way as the standard clockwork events.

## Usage instructions

See the updated README for details.

## Work in this commit

 * updated README to clarify, and explain usage

 * refactored how we determine whether a model has changed when we sync the models. Previously we checked if the `name`, `frequency` or `at` values had changed, and needed some complicated code to compare the `model#at` with those stored in each event created by clockwork (corresponding to a different `at` time.)

   The new approach simply expects models to have an `#attributes` method (which ActiveRecord models already do) which outputs the attribute state as a hash. Now we simply store this, and then check to see if the state has changed when we sync.

   Although the public API is the same, this change could potentially cause a subtle change in behaviour in terms of syncing events, and for that reason we'll need to bump the major version

 * made the `at` method optional for database event models (previously we required it to be defined, and to return either `nil` or `''`)

## Issues Resolved

* resolves #153
* resolves #147
* resolves #113