### PR TITLE
Blacklist selected attributes for comparison

### DIFF
--- a/clockwork.gemspec
+++ b/clockwork.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "clockwork"
-  s.version = "2.0.0"
+  s.version = "2.0.1"
 
   s.authors = ["Adam Wiggins", "tomykaira"]
   s.license = 'MIT'

--- a/lib/clockwork/database_events/event_collection.rb
+++ b/lib/clockwork/database_events/event_collection.rb
@@ -14,7 +14,14 @@ module Clockwork
       def has_changed?(model)
         return true if event.nil?
 
-        event.model_attributes != model.attributes
+        ignored_attributes = model.ignored_attributes if model.respond_to?(:ignored_attributes)
+        ignored_attributes ||= []
+
+        model_attributes = model.attributes.select do |k, _|
+          not ignored_attributes.include?(k.to_sym)
+        end
+
+        event.model_attributes != model_attributes
       end
 
       def unregister

--- a/lib/clockwork/database_events/event_store.rb
+++ b/lib/clockwork/database_events/event_store.rb
@@ -112,15 +112,19 @@ module Clockwork
         options = {
           :from_database => true,
           :synchronizer => self,
+          :ignored_attributes => [],
         }
 
         options[:at] = at_strings_for(model) if model.respond_to?(:at)
         options[:if] = ->(time){ model.if?(time) } if model.respond_to?(:if?)
         options[:tz] = model.tz if model.respond_to?(:tz)
+        options[:ignored_attributes] = model.ignored_attributes if model.respond_to?(:ignored_attributes)
 
         # store the state of the model at time of registering so we can
         # easily compare and determine if state has changed later
-        options[:model_attributes] = model.attributes
+        options[:model_attributes] = model.attributes.select do |k, v|
+          not options[:ignored_attributes].include?(k.to_sym)
+        end
 
         options
       end


### PR DESCRIPTION
Currently, Clockwork determines if it should reload (unregister and re-register) an event by comparing the attributes of the model.

But what if I want to be able to update my model, but not trigger that behavior in Clockwork? Specifically, in my instance, I have an attribute called "executed_at" that I update upon every run. 

With the default behavior, my event gets triggered every time Clockwork syncs events from the database, which is bad.

I've added a new optional method, `ignored_attributes` which removes specified attributes from the comparison pool, and allows you to update your model without triggering an event reload.